### PR TITLE
Reset schema of internal topics when they are deleted 

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     id("com.bakdata.sonar") version "1.1.6"
     id("com.bakdata.sonatype") version "1.1.6"
     id("org.hildan.github.changelog") version "0.8.0"
-    id("com.commercehub.gradle.plugin.avro") version "0.17.0"
+    id("com.github.davidmc24.gradle.plugin.avro") version "1.2.0"
     id("io.freefair.lombok") version "5.1.1"
 }
 

--- a/src/main/java/com/bakdata/kafka/CleanUpRunner.java
+++ b/src/main/java/com/bakdata/kafka/CleanUpRunner.java
@@ -128,6 +128,8 @@ public final class CleanUpRunner {
         final List<String> inputTopics = this.topologyInformation.getExternalSourceTopics();
         final List<String> intermediateTopics = this.topologyInformation.getIntermediateTopics();
         runResetter(inputTopics, intermediateTopics, this.adminClient, this.appId);
+        // the StreamsResetter is responsible for deleting internal topics
+        this.topologyInformation.getInternalTopics().forEach(this.adminClient.getSchemaTopicClient()::resetSchemaRegistry);
         if (deleteOutputTopic) {
             this.deleteTopics();
             this.deleteConsumerGroup();
@@ -143,8 +145,6 @@ public final class CleanUpRunner {
 
     public void deleteTopics() {
         final SchemaTopicClient schemaTopicClient = this.adminClient.getSchemaTopicClient();
-        // the StreamsResetter is responsible for deleting internal topics
-        this.topologyInformation.getInternalTopics().forEach(schemaTopicClient::resetSchemaRegistry);
         final List<String> externalTopics = this.topologyInformation.getExternalSinkTopics();
         externalTopics.forEach(schemaTopicClient::deleteTopicAndResetSchemaRegistry);
     }

--- a/src/test/java/com/bakdata/kafka/integration/StreamsCleanUpTest.java
+++ b/src/test/java/com/bakdata/kafka/integration/StreamsCleanUpTest.java
@@ -69,7 +69,6 @@ import org.assertj.core.api.junit.jupiter.SoftAssertionsExtension;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -418,18 +417,16 @@ class StreamsCleanUpTest {
         this.kafkaCluster.send(sendRequest);
         this.runApp();
         Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
-        softly.assertThat(client.getAllSubjects())
-                .contains(manualSubject);
+        softly.assertThat(client.getAllSubjects()).contains(manualSubject);
         this.runCleanUpWithDeletion();
-        softly.assertThat(client.getAllSubjects())
-                .doesNotContain(manualSubject);
+        softly.assertThat(client.getAllSubjects()).doesNotContain(manualSubject);
     }
 
     @Test
     void shouldCallClose(final SoftAssertions softly) throws InterruptedException {
         final CloseFlagApp closeApplication = this.createCloseApplication();
         this.app = closeApplication;
-        this.kafkaCluster.createTopic(TopicConfig.forTopic(this.app.getInputTopic()).useDefaults());
+        this.kafkaCluster.createTopic(TopicConfig.withName(this.app.getInputTopic()).useDefaults());
         Thread.sleep(TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS));
         // if we don't run the app, the coordinator will be unavailable
         this.runApp();
@@ -521,7 +518,7 @@ class StreamsCleanUpTest {
     }
 
     private KafkaStreamsApplication createComplexApplication() {
-        this.kafkaCluster.createTopic(TopicConfig.forTopic(ComplexTopologyApplication.THROUGH_TOPIC).useDefaults());
+        this.kafkaCluster.createTopic(TopicConfig.withName(ComplexTopologyApplication.THROUGH_TOPIC).useDefaults());
         return this.setupApp(new ComplexTopologyApplication(), "input", "output", "value_error");
     }
 


### PR DESCRIPTION
Previously, a clean-up run reset the schema of internal topics only when `--delete-output` was set. The topics themselves however were deleted even without the flag.
With this PR, the flag is no longer required.