### PR TITLE
Fix service selector to match pod labels

### DIFF
--- a/charts/producer-app/templates/service.yaml
+++ b/charts/producer-app/templates/service.yaml
@@ -13,7 +13,10 @@ metadata:
 spec:
   selector:
     app: {{ template "producer-app.name" . }}
-    chart: {{ template "producer-app.chart" . }}
+    release: {{ .Release.Name }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
   ports:
   {{- range .Values.ports }}
     {{- if .servicePort }}

--- a/charts/producer-app/templates/service.yaml
+++ b/charts/producer-app/templates/service.yaml
@@ -14,9 +14,6 @@ spec:
   selector:
     app: {{ template "producer-app.name" . }}
     release: {{ .Release.Name }}
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
   ports:
   {{- range .Values.ports }}
     {{- if .servicePort }}

--- a/charts/producer-app/values.yaml
+++ b/charts/producer-app/values.yaml
@@ -1,7 +1,5 @@
 nameOverride: bakdata-producer-app
 
-replicaCount: 1
-
 image: producerApp
 imageTag: latest
 imagePullPolicy: Always
@@ -11,7 +9,7 @@ imagePullSecrets: []
 # if true, deploy as kubernetes deployment instead of CronJob/Job
 deployment: false
 # Optional, applied for deployment:
-# replicaCount: 1
+replicaCount: 1
 
 restartPolicy: OnFailure
 

--- a/charts/producer-app/values.yaml
+++ b/charts/producer-app/values.yaml
@@ -9,7 +9,7 @@ imagePullSecrets: []
 # if true, deploy as kubernetes deployment instead of CronJob/Job
 deployment: false
 # Optional, applied for deployment:
-#replicaCount: 1
+# replicaCount: 1
 
 restartPolicy: OnFailure
 

--- a/charts/producer-app/values.yaml
+++ b/charts/producer-app/values.yaml
@@ -1,5 +1,7 @@
 nameOverride: bakdata-producer-app
 
+replicaCount: 1
+
 image: producerApp
 imageTag: latest
 imagePullPolicy: Always

--- a/charts/producer-app/values.yaml
+++ b/charts/producer-app/values.yaml
@@ -9,7 +9,7 @@ imagePullSecrets: []
 # if true, deploy as kubernetes deployment instead of CronJob/Job
 deployment: false
 # Optional, applied for deployment:
-replicaCount: 1
+#replicaCount: 1
 
 restartPolicy: OnFailure
 

--- a/charts/streams-app/templates/service.yaml
+++ b/charts/streams-app/templates/service.yaml
@@ -14,9 +14,6 @@ spec:
   selector:
     app: {{ template "streams-app.name" . }}
     release: {{ .Release.Name }}
-    {{- range $key, $value := .Values.labels }}
-    {{ $key }}: {{ $value }}
-    {{- end }}
   ports:
   {{- range .Values.ports }}
     {{- if .servicePort }}

--- a/charts/streams-app/templates/service.yaml
+++ b/charts/streams-app/templates/service.yaml
@@ -13,7 +13,10 @@ metadata:
 spec:
   selector:
     app: {{ template "streams-app.name" . }}
-    chart: {{ template "streams-app.chart" . }}
+    release: {{ .Release.Name }}
+    {{- range $key, $value := .Values.labels }}
+    {{ $key }}: {{ $value }}
+    {{- end }}
   ports:
   {{- range .Values.ports }}
     {{- if .servicePort }}


### PR DESCRIPTION
This PR fixes an issue related to the [new support of the services](https://github.com/bakdata/streams-bootstrap/pull/178) in Streams Bootstrap.
The service selector did not match the pod(s) labels. Therefore the service was not able to find the pod(s). So [the service has no Endpoints](https://kubernetes.io/docs/tasks/debug/debug-application/debug-service/#does-the-service-have-any-endpoints).