### PR TITLE
Add slf4j dependency

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,6 +19,7 @@ resources:
     - repository: templates
       type: github
       name: bakdata/bakdata-project-templates
+      ref: tmp/upload-snapshot
       endpoint: bot
 
 jobs:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,6 @@ resources:
     - repository: templates
       type: github
       name: bakdata/bakdata-project-templates
-      ref: tmp/upload-snapshot
       endpoint: bot
 
 jobs:

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,5 +3,5 @@ org.gradle.caching=true
 org.gradle.parallel=true
 kafkaVersion=3.5.1
 confluentVersion=7.5.1
-fluentKafkaVersion=2.11.0
+fluentKafkaVersion=2.11.1
 org.gradle.jvmargs=-Xmx2048m

--- a/streams-bootstrap/build.gradle.kts
+++ b/streams-bootstrap/build.gradle.kts
@@ -17,7 +17,7 @@ dependencies {
     val log4jVersion = "2.21.1"
     implementation(group = "org.apache.logging.log4j", name = "log4j-core", version = log4jVersion)
     implementation(group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version = log4jVersion)
-    implementation(group = "org.slf4j", name = "slf4j-api", version = "2.0.6")
+    api(group = "org.slf4j", name = "slf4j-api", version = "2.0.6") // required because other dependencies use Slf4j 1.x which is not properly resolved if this library is used in test scope
     implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
     implementation(group = "org.jooq", name = "jool", version = "0.9.14")
 

--- a/streams-bootstrap/build.gradle.kts
+++ b/streams-bootstrap/build.gradle.kts
@@ -17,7 +17,11 @@ dependencies {
     val log4jVersion = "2.21.1"
     implementation(group = "org.apache.logging.log4j", name = "log4j-core", version = log4jVersion)
     implementation(group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version = log4jVersion)
-    api(group = "org.slf4j", name = "slf4j-api", version = "2.0.6") // required because other dependencies use Slf4j 1.x which is not properly resolved if this library is used in test scope
+    api(
+        group = "org.slf4j",
+        name = "slf4j-api",
+        version = "2.0.6"
+    ) // required because other dependencies use Slf4j 1.x which is not properly resolved if this library is used in test scope
     implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
     implementation(group = "org.jooq", name = "jool", version = "0.9.14")
 

--- a/streams-bootstrap/build.gradle.kts
+++ b/streams-bootstrap/build.gradle.kts
@@ -17,6 +17,7 @@ dependencies {
     val log4jVersion = "2.21.1"
     implementation(group = "org.apache.logging.log4j", name = "log4j-core", version = log4jVersion)
     implementation(group = "org.apache.logging.log4j", name = "log4j-slf4j2-impl", version = log4jVersion)
+    implementation(group = "org.slf4j", name = "slf4j-api", version = "2.0.6")
     implementation(group = "com.google.guava", name = "guava", version = "31.1-jre")
     implementation(group = "org.jooq", name = "jool", version = "0.9.14")
 


### PR DESCRIPTION
Some dependencies of streams-bootstrap provide Slf4j 1.x as an api dependency themselves, preventing Log4j2 binding to be properly set up