### PR TITLE
Use same variable names for clean up job as for main chart

### DIFF
--- a/charts/producer-app-cleanup-job/templates/_helpers.tpl
+++ b/charts/producer-app-cleanup-job/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "producer-app-cleanup-job.name" -}}
+{{- define "producer-app.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -12,7 +12,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "producer-app-cleanup-job.fullname" -}}
+{{- define "producer-app.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -24,6 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "producer-app-cleanup-job.chart" -}}
+{{- define "producer-app.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/producer-app-cleanup-job/templates/configmap.yaml
+++ b/charts/producer-app-cleanup-job/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "producer-app-cleanup-job.name" . }}
+  name: {{ template "producer-app.name" . }}
 data:
   {{- range $key, $value := .Values.files }}
   {{ $key }}: {{ $value.content | quote }}

--- a/charts/producer-app-cleanup-job/templates/job.yaml
+++ b/charts/producer-app-cleanup-job/templates/job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "producer-app-cleanup-job.fullname" . }}
+  name: {{ template "producer-app.fullname" . }}
 {{- if .Values.annotations }}
   annotations:
   {{- range $key, $value := .Values.annotations }}
@@ -10,8 +10,8 @@ metadata:
   {{- end }}
 {{- end }}
   labels:
-    app: {{ template "producer-app-cleanup-job.name" . }}
-    chart: {{ template "producer-app-cleanup-job.chart" . }}
+    app: {{ template "producer-app.name" . }}
+    chart: {{ template "producer-app.chart" . }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value }}
@@ -27,7 +27,7 @@ spec:
       {{- end }}
     {{- end }}
       labels:
-        app: {{ template "producer-app-cleanup-job.name" . }}
+        app: {{ template "producer-app.name" . }}
         release: {{ .Release.Name }}
         {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value }}
@@ -50,7 +50,7 @@ spec:
 {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "producer-app-cleanup-job.name" . }}
+        - name: {{ template "producer-app.name" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           resources:
@@ -88,7 +88,7 @@ spec:
             - name: "{{ $key }}"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "producer-app-cleanup-job.fullname" $ }}
+                  name: {{ template "producer-app.fullname" $ }}
                   key: "{{ $key }}"
             {{- end }}
             {{- range $key, $value := .Values.secretRefs }}
@@ -132,7 +132,7 @@ spec:
         {{- if .Values.files }}
         - name: config
           configMap:
-            name: {{ template "producer-app-cleanup-job.name" . }}
+            name: {{ template "producer-app.name" . }}
         {{- end }}
         {{- range .Values.secretFilesRefs }}
         - name: {{ .volume }}

--- a/charts/producer-app-cleanup-job/templates/secrets.yaml
+++ b/charts/producer-app-cleanup-job/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "producer-app-cleanup-job.fullname" . }}
+  name: {{ template "producer-app.fullname" . }}
 type: Opaque
 data:
   {{- range $key, $value := .Values.secrets }}

--- a/charts/streams-app-cleanup-job/templates/_helpers.tpl
+++ b/charts/streams-app-cleanup-job/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "streams-app-cleanup-job.name" -}}
+{{- define "streams-app.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -12,7 +12,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "streams-app-cleanup-job.fullname" -}}
+{{- define "streams-app.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -24,6 +24,6 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "streams-app-cleanup-job.chart" -}}
+{{- define "streams-app.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/streams-app-cleanup-job/templates/configmap.yaml
+++ b/charts/streams-app-cleanup-job/templates/configmap.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "streams-app-cleanup-job.name" . }}
+  name: {{ template "streams-app.name" . }}
 data:
   {{- range $key, $value := .Values.files }}
   {{ $key }}: {{ $value.content | quote }}

--- a/charts/streams-app-cleanup-job/templates/job.yaml
+++ b/charts/streams-app-cleanup-job/templates/job.yaml
@@ -2,7 +2,7 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: {{ template "streams-app-cleanup-job.fullname" . }}
+  name: {{ template "streams-app.fullname" . }}
 {{- if .Values.annotations }}
   annotations:
   {{- range $key, $value := .Values.annotations }}
@@ -10,8 +10,8 @@ metadata:
   {{- end }}
 {{- end }}
   labels:
-    app: {{ template "streams-app-cleanup-job.name" . }}
-    chart: {{ template "streams-app-cleanup-job.chart" . }}
+    app: {{ template "streams-app.name" . }}
+    chart: {{ template "streams-app.chart" . }}
     release: {{ .Release.Name }}
     {{- range $key, $value := .Values.labels }}
     {{ $key }}: {{ $value }}
@@ -27,7 +27,7 @@ spec:
       {{- end }}
     {{- end }}
       labels:
-        app: {{ template "streams-app-cleanup-job.name" . }}
+        app: {{ template "streams-app.name" . }}
         release: {{ .Release.Name }}
         {{- range $key, $value := .Values.podLabels }}
         {{ $key }}: {{ $value }}
@@ -50,7 +50,7 @@ spec:
 {{- toYaml .Values.imagePullSecrets | nindent 8 }}
       {{- end }}
       containers:
-        - name: {{ template "streams-app-cleanup-job.name" . }}
+        - name: {{ template "streams-app.name" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           resources:
@@ -117,7 +117,7 @@ spec:
             - name: "{{ $key }}"
               valueFrom:
                 secretKeyRef:
-                  name: {{ template "streams-app-cleanup-job.fullname" $ }}
+                  name: {{ template "streams-app.fullname" $ }}
                   key: "{{ $key }}"
             {{- end }}
             {{- range $key, $value := .Values.secretRefs }}
@@ -161,7 +161,7 @@ spec:
         {{- if .Values.files }}
         - name: config
           configMap:
-            name: {{ template "streams-app-cleanup-job.name" . }}
+            name: {{ template "streams-app.name" . }}
         {{- end }}
         {{- range .Values.secretFilesRefs }}
         - name: {{ .volume }}

--- a/charts/streams-app-cleanup-job/templates/secrets.yaml
+++ b/charts/streams-app-cleanup-job/templates/secrets.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ template "streams-app-cleanup-job.fullname" . }}
+  name: {{ template "streams-app.fullname" . }}
 type: Opaque
 data:
   {{- range $key, $value := .Values.secrets }}


### PR DESCRIPTION
Using templating variables in affinities is broken since #224 