### PR TITLE
Do not configure replicas if autoscaling is enabled

### DIFF
--- a/charts/streams-app/templates/deployment.yaml
+++ b/charts/streams-app/templates/deployment.yaml
@@ -28,7 +28,7 @@ spec:
   serviceName: {{ template "streams-app.name" . }}
   podManagementPolicy: Parallel
   {{- end }}
-  {{- if .Values.replicaCount }}
+  {{- if (not .Values.autoscaling.enabled) }}
   replicas: {{ .Values.replicaCount }}
   {{- end }}
   selector:

--- a/charts/streams-app/templates/deployment.yaml
+++ b/charts/streams-app/templates/deployment.yaml
@@ -28,7 +28,9 @@ spec:
   serviceName: {{ template "streams-app.name" . }}
   podManagementPolicy: Parallel
   {{- end }}
+  {{- if .Values.replicaCount }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       app: {{ template "streams-app.name" . }}

--- a/charts/streams-app/values.yaml
+++ b/charts/streams-app/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: bakdata-streams-app
 
-replicaCount: 1
+# replicaCount: 1
 
 image: streamsApp
 imageTag: latest

--- a/charts/streams-app/values.yaml
+++ b/charts/streams-app/values.yaml
@@ -1,6 +1,6 @@
 nameOverride: bakdata-streams-app
 
-# replicaCount: 1
+replicaCount: 1
 
 image: streamsApp
 imageTag: latest


### PR DESCRIPTION
Currently, if a ScaledObject is [paused](https://keda.sh/docs/2.16/concepts/scaling-deployments/#pausing-autoscaling), and the Helm release is updated, the deployment is scaled according to replicaCount but KEDA is not re-pausing the deployment