### PR TITLE
Exclude Slf4j 1.x dependencies

### DIFF
--- a/streams-bootstrap-cli/build.gradle.kts
+++ b/streams-bootstrap-cli/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
     api(project(":streams-bootstrap-core"))
     api(libs.picocli)
+    implementation(libs.slf4j)
 
     testRuntimeOnly(libs.junit.platform.launcher)
     testImplementation(libs.junit.jupiter)

--- a/streams-bootstrap-core/build.gradle.kts
+++ b/streams-bootstrap-core/build.gradle.kts
@@ -15,11 +15,13 @@ dependencies {
     api(libs.kafka.clients)
     implementation(libs.kafka.schema.serializer) {
         exclude(group = "org.apache.kafka", module = "kafka-clients") // force usage of OSS kafka-clients
+        exclude(group = "org.slf4j", module = "slf4j-api") // Conflict with 2.x when used as dependency
     }
     api(libs.kafka.schema.registry.client) {
         exclude(group = "org.apache.kafka", module = "kafka-clients") // force usage of OSS kafka-clients
+        exclude(group = "org.slf4j", module = "slf4j-api") // Conflict with 2.x when used as dependency
     }
-    api(libs.slf4j)
+    implementation(libs.slf4j)
     implementation(libs.jool)
     implementation(libs.resilience4j.retry)
     api(platform(libs.errorHandling.bom))

--- a/streams-bootstrap-core/build.gradle.kts
+++ b/streams-bootstrap-core/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
     api(libs.kafka.schema.registry.client) {
         exclude(group = "org.apache.kafka", module = "kafka-clients") // force usage of OSS kafka-clients
     }
-    implementation(libs.slf4j)
+    api(libs.slf4j)
     implementation(libs.jool)
     implementation(libs.resilience4j.retry)
     api(platform(libs.errorHandling.bom))

--- a/streams-bootstrap-test/build.gradle.kts
+++ b/streams-bootstrap-test/build.gradle.kts
@@ -7,4 +7,5 @@ plugins {
 dependencies {
     api(project(":streams-bootstrap-core"))
     api(libs.fluentKafkaStreamsTests)
+    implementation(libs.slf4j)
 }


### PR DESCRIPTION
Confluent dependencies expose 1.7

Has been reverted in https://github.com/bakdata/streams-bootstrap/commit/c062c09ea4ca5a8bff37a944c13c6fd1dc493c54#diff-71c8e959bec159ef22ed15dd8c30aa80fa4270de0d32935f900978db9d70f0a1R16-R25 for no real reason